### PR TITLE
Add build.number at BentoBox version

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: BentoBox
 main: world.bentobox.bentobox.BentoBox
-version: ${project.version}
+version: ${project.version}${build.number}
 api-version: 1.13
 
 authors: [tastybento, Poslovitch]


### PR DESCRIPTION
This will allow to know which snapshot build is used in current build.